### PR TITLE
Remove test files from the built gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.3
 script:
   - 'bundle exec rspec'
 

--- a/briskly.gemspec
+++ b/briskly.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   }
   gem.homepage      = 'http://github.com/pedrocunha/briskly'
   gem.license       = 'MIT'
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = Dir.glob("lib/**/*") + %w(README.md LICENSE)
   gem.require_paths = ['lib']
   gem.version       = Briskly::VERSION
 


### PR DESCRIPTION
Bundler and Rubygems haven't come into a final solution to avoid
building gems with their respective test files. Although there's no good
reason to have them installed in production.

<img width="631" alt="screen shot 2016-04-18 at 21 42 48" src="https://cloud.githubusercontent.com/assets/136777/14619594/1a9278a6-05b0-11e6-9bee-831332317498.png">

[Rubygems discussion](https://github.com/rubygems/rubygems/issues/735)
